### PR TITLE
Rewrote URLs to be constructed from the app path

### DIFF
--- a/app/application/views/homepage.php
+++ b/app/application/views/homepage.php
@@ -5,21 +5,23 @@
         <title>Home</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         
+        <?php $this->load->helper('url'); ?>
+        
         <!-- Popper JS -->
-        <script src="../static/js/popper.min.js"></script>
+        <script src="<?php echo base_url('/static/js/popper.min.js'); ?>"></script>
         
         <!-- Vendor JS -->
-        <script src="../static/js/jquery.min.js"></script>
-        <script src="../static/js/bootstrap.min.js"></script>
+        <script src="<?php echo base_url('/static/js/jquery.min.js'); ?>"></script>
+        <script src="<?php echo base_url('/static/js/bootstrap.min.js'); ?>"></script>
         
         <!-- App JS -->
-        <script src="../static/js/homepage.js"></script>
+        <script src="<?php echo base_url('/static/js/homepage.js'); ?>"></script>
 
         <!-- Vendor CSS -->
-        <link rel="stylesheet" href="../static/css/bootstrap.css">
+        <link rel="stylesheet" href="<?php echo base_url('/static/css/bootstrap.css'); ?>">
 
         <!-- App CSS -->
-        <link rel="stylesheet" href="../static/css/homepage.css" type="text/css">
+        <link rel="stylesheet" href="<?php echo base_url('/static/css/homepage.css'); ?>" type="text/css">
 
     </head>
 

--- a/app/application/views/onboarding_1_welcome.php
+++ b/app/application/views/onboarding_1_welcome.php
@@ -5,18 +5,20 @@
         <title>Welcome</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         
-        <!-- Vendor JS -->
-        <script src="../../static/js/jquery.min.js"></script>
-        <script src="../../static/js/bootstrap.min.js"></script>
+        <?php $this->load->helper('url'); ?>
 
+        <!-- Vendor JS -->
+        <script src="<?php echo base_url('/static/js/jquery.min.js'); ?>"></script>
+        <script src="<?php echo base_url('/static/js/bootstrap.min.js'); ?>"></script>
+        
         <!-- App JS -->
-        <script src="../../static/js/homepage.js"></script>
+        <script src="<?php echo base_url('/static/js/homepage.js'); ?>"></script>
 
         <!-- Vendor CSS -->
-        <link rel="stylesheet" href="../../static/css/bootstrap.css">
+        <link rel="stylesheet" href="<?php echo base_url('/static/css/bootstrap.css'); ?>">
 
         <!-- App CSS -->
-        <link rel="stylesheet" href="../../static/css/homepage.css" type="text/css">
+        <link rel="stylesheet" href="<?php echo base_url('/static/css/homepage.css'); ?>" type="text/css">
 
     </head>
 
@@ -45,7 +47,7 @@
                             <h1>Welcome!</h1>
                             <h6>You are registering as username <?php echo $cis_username ?>.</h6>
                             <p><br />Thank you for signing up to Durham University's Volunteering Project. With this account you can organize and track your volunteering activities.</p>
-                            <a href="steps_details">
+                            <a href="<?php echo site_url('/onboard/steps_details'); ?>">
                                 <button class="btn btn-primary">Continue</button>
                             </a>
                         </div>

--- a/app/application/views/onboarding_3_enter_details_form.php
+++ b/app/application/views/onboarding_3_enter_details_form.php
@@ -5,18 +5,20 @@
         <title>Personal Details</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         
-        <!-- Vendor JS -->
-        <script src="../../static/js/jquery.min.js"></script>
-        <script src="../../static/js/bootstrap.min.js"></script>
+        <?php $this->load->helper('url'); ?>
 
+        <!-- Vendor JS -->
+        <script src="<?php echo base_url('/static/js/jquery.min.js'); ?>"></script>
+        <script src="<?php echo base_url('/static/js/bootstrap.min.js'); ?>"></script>
+        
         <!-- App JS -->
-        <script src="../../static/js/homepage.js"></script>
+        <script src="<?php echo base_url('/static/js/homepage.js'); ?>"></script>
 
         <!-- Vendor CSS -->
-        <link rel="stylesheet" href="../../static/css/bootstrap.css">
+        <link rel="stylesheet" href="<?php echo base_url('/static/css/bootstrap.css'); ?>">
 
         <!-- App CSS -->
-        <link rel="stylesheet" href="../../static/css/homepage.css" type="text/css">
+        <link rel="stylesheet" href="<?php echo base_url('/static/css/homepage.css'); ?>" type="text/css">
 
     </head>
 
@@ -47,7 +49,7 @@
                             <div class="card">
 
                                 <div class="card-block">
-                                    <form action="send_details" method="post">
+                                    <form action="<?php echo site_url('/onboard/send_details'); ?>" method="post">
 
                                         <div class="form-group">
                                             <label for="exampleInputEmail1">First Name</label>

--- a/app/application/views/onboarding_5_nominate_manager_form.php
+++ b/app/application/views/onboarding_5_nominate_manager_form.php
@@ -5,18 +5,20 @@
         <title>Manager Nomination</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         
-        <!-- Vendor JS -->
-        <script src="../../static/js/jquery.min.js"></script>
-        <script src="../../static/js/bootstrap.min.js"></script>
+        <?php $this->load->helper('url'); ?>
 
+        <!-- Vendor JS -->
+        <script src="<?php echo base_url('/static/js/jquery.min.js'); ?>"></script>
+        <script src="<?php echo base_url('/static/js/bootstrap.min.js'); ?>"></script>
+        
         <!-- App JS -->
-        <script src="../../static/js/homepage.js"></script>
+        <script src="<?php echo base_url('/static/js/homepage.js'); ?>"></script>
 
         <!-- Vendor CSS -->
-        <link rel="stylesheet" href="../../static/css/bootstrap.css">
+        <link rel="stylesheet" href="<?php echo base_url('/static/css/bootstrap.css'); ?>">
 
         <!-- App CSS -->
-        <link rel="stylesheet" href="../../static/css/homepage.css" type="text/css">
+        <link rel="stylesheet" href="<?php echo base_url('/static/css/homepage.css'); ?>" type="text/css">
 
     </head>
 
@@ -46,7 +48,7 @@
 
                             <div class="card">
                                 <div class="card-block">
-                                    <form action="send_nominate_manager" method="post">
+                                    <form action="<?php echo site_url('/onboard/send_nominate_manager'); ?>" method="post">
                                         <div class="form-group">
                                             <label for="exampleInputEmail1">Email address</label>
                                             <input type="email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp" placeholder="Enter email">

--- a/app/application/views/onboarding_steps.php
+++ b/app/application/views/onboarding_steps.php
@@ -5,18 +5,20 @@
         <title>Onboarding</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         
-        <!-- Vendor JS -->
-        <script src="../../static/js/jquery.min.js"></script>
-        <script src="../../static/js/bootstrap.min.js"></script>
+        <?php $this->load->helper('url'); ?>
 
+        <!-- Vendor JS -->
+        <script src="<?php echo base_url('/static/js/jquery.min.js'); ?>"></script>
+        <script src="<?php echo base_url('/static/js/bootstrap.min.js'); ?>"></script>
+        
         <!-- App JS -->
-        <script src="../../static/js/homepage.js"></script>
+        <script src="<?php echo base_url('/static/js/homepage.js'); ?>"></script>
 
         <!-- Vendor CSS -->
-        <link rel="stylesheet" href="../../static/css/bootstrap.css">
+        <link rel="stylesheet" href="<?php echo base_url('/static/css/bootstrap.css'); ?>">
 
         <!-- App CSS -->
-        <link rel="stylesheet" href="../../static/css/homepage.css" type="text/css">
+        <link rel="stylesheet" href="<?php echo base_url('/static/css/homepage.css'); ?>" type="text/css">
 
     </head>
 
@@ -53,7 +55,7 @@
                             <p class="card-text">Enter or change your personal information.</p>
                         </div>
                         <ul class="list-group list-group-flush">
-                            <a href="enter_details"><li class="list-group-item"><?php if ($active == "enter_details") { echo "&rarr; "; } ?> Enter your details</li></a>
+                            <a href="<?php echo site_url('/onboard/enter_details'); ?>"><li class="list-group-item"><?php if ($active == "enter_details") { echo "&rarr; "; } ?> Enter your details</li></a>
                         </ul>
                     </div>
                 </div>
@@ -67,7 +69,7 @@
                             <p class="card-text">Your manager gives you permission to use a specified time during working hours for volunteering.</p>
                         </div>
                         <ul class="list-group list-group-flush">
-                            <a href="enter_nominate_manager"><li class="list-group-item"><?php if ($active == "nominate_manager") { echo "&rarr; "; } ?>Nominate a manager</li></a>
+                            <a href="<?php echo site_url('/onboard/enter_nominate_manager'); ?>"><li class="list-group-item"><?php if ($active == "nominate_manager") { echo "&rarr; "; } ?>Nominate a manager</li></a>
                         </ul>
                     </div>
                 </div>
@@ -81,7 +83,7 @@
                             <p class="card-text">Go to your personal homepage to start organizing and tracking your volunteering activities.</p>
                         </div>
                         <ul class="list-group list-group-flush">
-                            <a href="home"><li class="list-group-item"><?php if ($active == "get_started") { echo "&rarr; "; } ?>Go to app</li></a>
+                            <a href="<?php echo site_url('/home'); ?>"><li class="list-group-item"><?php if ($active == "get_started") { echo "&rarr; "; } ?>Go to app</li></a>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
Instead of just using relative URLs, this build absolute URLs from a configured variable name. It will help us not get tangled up in paths when we start templating and rendering emails later on.

Please check that these work on your local installs.

It relies on setting the `base_url` in `/app/application/config/config.php` to whatever you've got as your dev copy. You should *not* then commit that variable, as it's instance specific.

Need reviews from both @JDiggers and @williamejelias.